### PR TITLE
refactor click outside with custom hook

### DIFF
--- a/client/src/assets/style/tailwind.css
+++ b/client/src/assets/style/tailwind.css
@@ -470,46 +470,16 @@ Ensure the default browser behavior of the `hidden` attribute.
   --tw-backdrop-sepia:  ;
 }
 
-.container{
-  width: 100%;
-}
-
-@media (min-width: 400px){
-  .container{
-    max-width: 400px;
-  }
-}
-
-@media (min-width: 480px){
-  .container{
-    max-width: 480px;
-  }
-}
-
-@media (min-width: 740px){
-  .container{
-    max-width: 740px;
-  }
-}
-
-@media (min-width: 976px){
-  .container{
-    max-width: 976px;
-  }
-}
-
-@media (min-width: 1440px){
-  .container{
-    max-width: 1440px;
-  }
-}
-
 .absolute{
   position: absolute;
 }
 
 .relative{
   position: relative;
+}
+
+.right-0{
+  right: 0px;
 }
 
 .bottom-0{
@@ -520,16 +490,24 @@ Ensure the default browser behavior of the `hidden` attribute.
   left: 0px;
 }
 
-.right-0{
-  right: 0px;
-}
-
 .bottom-1{
   bottom: 0.25rem;
 }
 
 .left-2{
   left: 0.5rem;
+}
+
+.z-10{
+  z-index: 10;
+}
+
+.col-start-2{
+  grid-column-start: 2;
+}
+
+.col-start-3{
+  grid-column-start: 3;
 }
 
 .mx-auto{
@@ -631,6 +609,10 @@ Ensure the default browser behavior of the `hidden` attribute.
   width: 100%;
 }
 
+.w-\[200px\]{
+  width: 200px;
+}
+
 .w-\[89\%\]{
   width: 89%;
 }
@@ -649,6 +631,10 @@ Ensure the default browser behavior of the `hidden` attribute.
 
 .min-w-\[50\%\]{
   min-width: 50%;
+}
+
+.max-w-\[1400px\]{
+  max-width: 1400px;
 }
 
 .max-w-fit{
@@ -679,8 +665,8 @@ Ensure the default browser behavior of the `hidden` attribute.
   flex-grow: 1;
 }
 
-.grid-cols-2{
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+.grid-cols-\[1fr_minmax\(0\2c _3fr\)_1fr\]{
+  grid-template-columns: 1fr minmax(0, 3fr) 1fr;
 }
 
 .flex-col{
@@ -689,6 +675,10 @@ Ensure the default browser behavior of the `hidden` attribute.
 
 .place-items-center{
   place-items: center;
+}
+
+.items-start{
+  align-items: flex-start;
 }
 
 .items-center{
@@ -715,24 +705,18 @@ Ensure the default browser behavior of the `hidden` attribute.
   justify-content: space-between;
 }
 
-.justify-around{
-  justify-content: space-around;
-}
-
-.justify-evenly{
-  justify-content: space-evenly;
-}
-
 .gap-8{
   gap: 2rem;
 }
 
-.gap-10{
-  gap: 2.5rem;
+.gap-6{
+  gap: 1.5rem;
 }
 
-.gap-4{
-  gap: 1rem;
+.space-y-2 > :not([hidden]) ~ :not([hidden]){
+  --tw-space-y-reverse: 0;
+  margin-top: calc(0.5rem * calc(1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(0.5rem * var(--tw-space-y-reverse));
 }
 
 .space-y-6 > :not([hidden]) ~ :not([hidden]){
@@ -775,12 +759,6 @@ Ensure the default browser behavior of the `hidden` attribute.
   --tw-space-x-reverse: 0;
   margin-right: calc(6rem * var(--tw-space-x-reverse));
   margin-left: calc(6rem * calc(1 - var(--tw-space-x-reverse)));
-}
-
-.space-y-2 > :not([hidden]) ~ :not([hidden]){
-  --tw-space-y-reverse: 0;
-  margin-top: calc(0.5rem * calc(1 - var(--tw-space-y-reverse)));
-  margin-bottom: calc(0.5rem * var(--tw-space-y-reverse));
 }
 
 .justify-self-start{
@@ -840,14 +818,14 @@ Ensure the default browser behavior of the `hidden` attribute.
   border-color: rgb(229 231 235 / var(--tw-border-opacity));
 }
 
-.bg-\[\#ff485a\]{
-  --tw-bg-opacity: 1;
-  background-color: rgb(255 72 90 / var(--tw-bg-opacity));
-}
-
 .bg-white{
   --tw-bg-opacity: 1;
   background-color: rgb(255 255 255 / var(--tw-bg-opacity));
+}
+
+.bg-\[\#ff485a\]{
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 72 90 / var(--tw-bg-opacity));
 }
 
 .bg-gray-300{
@@ -925,6 +903,16 @@ Ensure the default browser behavior of the `hidden` attribute.
   padding: 1.25rem;
 }
 
+.py-3{
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+}
+
+.px-6{
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+}
+
 .py-1{
   padding-top: 0.25rem;
   padding-bottom: 0.25rem;
@@ -963,11 +951,6 @@ Ensure the default browser behavior of the `hidden` attribute.
 .py-\[18em\]{
   padding-top: 18em;
   padding-bottom: 18em;
-}
-
-.px-6{
-  padding-left: 1.5rem;
-  padding-right: 1.5rem;
 }
 
 .py-\[11em\]{
@@ -1025,11 +1008,6 @@ Ensure the default browser behavior of the `hidden` attribute.
   font-weight: 600;
 }
 
-.text-gray-700{
-  --tw-text-opacity: 1;
-  color: rgb(55 65 81 / var(--tw-text-opacity));
-}
-
 .text-white{
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity));
@@ -1040,6 +1018,11 @@ Ensure the default browser behavior of the `hidden` attribute.
   color: rgb(255 72 90 / var(--tw-text-opacity));
 }
 
+.text-gray-700{
+  --tw-text-opacity: 1;
+  color: rgb(55 65 81 / var(--tw-text-opacity));
+}
+
 .text-gray-400{
   --tw-text-opacity: 1;
   color: rgb(156 163 175 / var(--tw-text-opacity));
@@ -1047,6 +1030,12 @@ Ensure the default browser behavior of the `hidden` attribute.
 
 .opacity-70{
   opacity: 0.7;
+}
+
+.shadow-sm{
+  --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
 .shadow-md{
@@ -1145,30 +1134,12 @@ Ensure the default browser behavior of the `hidden` attribute.
     max-width: 55%;
   }
 
-  .lg\:grid-cols-\[2fr_3fr_2fr\]{
-    grid-template-columns: 2fr 3fr 2fr;
-  }
-
   .lg\:grid-cols-2{
     grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .lg\:grid-cols-\[2fr_minmax\(0\2c _3fr\)_2fr\]{
-    grid-template-columns: 2fr minmax(0, 3fr) 2fr;
-  }
-
-  .lg\:grid-cols-\[1fr_minmax\(0\2c _3fr\)_1fr\]{
-    grid-template-columns: 1fr minmax(0, 3fr) 1fr;
   }
 
   .lg\:gap-x-2{
     -moz-column-gap: 0.5rem;
          column-gap: 0.5rem;
-  }
-}
-
-@media (min-width: 1440px){
-  .xl\:gap-10{
-    gap: 2.5rem;
   }
 }

--- a/client/src/components/layout/NavBar.js
+++ b/client/src/components/layout/NavBar.js
@@ -1,69 +1,58 @@
 import React from "react";
 import { useUser } from "../../services/UserContext";
 import LogoHomeButton from "../navigation/LogoHomeButton";
+import { HomeButton, AboutButton, HowItWorksButton, ContactButton, AccountButton } from "../navigation/ButtonIndex";
 import SignInButton from "../navigation/SignInButton";
 import SignOutButton from "../navigation/SignOutButton";
 import SignUpButton from "../navigation/SignUpButton";
+import NavDropDown from "../navigation/NavDropDown";
 
 const NavBar = () => {
   const user = useUser()
 
-  const userButtons = user ? (
-    [
-      <li 
-        key="account"
-        className="hover:text-[#ff485a]">
-        <button>Account</button>
-      </li>,
-      <li 
-        key="sign-out"
-        className="hover:text-[#ff485a]">
-        <SignOutButton />
-      </li>
-    ]
-  ) : (
-    [
-      <li 
-        key="sign-in"
-        className="hover:text-[#ff485a]"
-        role="button" >
-        <SignInButton />
-      </li>,
-      <li 
-        key="sign-up"
-        className="hover:text-[#ff485a]"
-        role="button" >
-        <SignUpButton />
-      </li>
-    ]
-  )
-
-  const menuButtons = [
-    <li className="hover:text-[#ff485a]">
-      <button>Home</button>
-    </li>,
-    <li className="hover:text-[#ff485a]">
-      <button>About</button>
-    </li>,
-    <li className="hover:text-[#ff485a]">
-      <button>Contact</button>
-    </li>,
-    <li className="hover:text-[#ff485a]">
-      <button>How It Works</button>
-    </li>
+  const navButtons = [
+    <HomeButton key="home" />,
+    <AboutButton key="about" />,
+    <HowItWorksButton key="how-it-works" />,
+    <ContactButton key="contact" />
   ]
 
+  const userButtons = user ? [
+    <AccountButton key="account" />,
+    <SignOutButton key="sign-out" />
+  ] : [
+    <SignInButton key="sign-in" />,
+    <SignUpButton key="sign-up" />
+  ]
+
+
   return (
-    <nav className="container mx-auto grid grid-cols-2 lg:grid-cols-[1fr_minmax(0,_3fr)_1fr] place-items-center p-6 text-xl">
-      <LogoHomeButton/>      
-      <ul className="hidden lg:flex gap-8">
-        { menuButtons }
-      </ul>
-      <button className="justify-self-end lg:hidden">Menu</button>
-      <ul className="hidden lg:flex gap-8 justify-self-end">
-        { userButtons }
-      </ul>
-    </nav>
+    <div className="w-full bg-white bg-opacity-50 shadow-sm">
+      <nav className="w-full max-w-[1400px] mx-auto grid grid-cols-[1fr_minmax(0,_3fr)_1fr] place-items-center py-3 px-6 text-xl">
+        <LogoHomeButton/>      
+        <ul className="hidden lg:flex col-start-2 gap-8">
+          { navButtons.map((button, index) => {
+            return (
+              <li key={ index } className="hover:text-[#ff485a]">
+                { button }
+              </li>
+            )
+          }) }
+        </ul>
+        <NavDropDown className="col-start-3 justify-self-end lg:hidden">
+          { [...navButtons, ...userButtons] }
+        </NavDropDown>
+        <ul className="hidden lg:flex col-start-3 gap-6 justify-self-end">
+          { userButtons.map((button, index) => {
+            return (
+              <li key={ index } className="hover:text-[#ff485a]">
+                { button }
+              </li>
+            )
+          }) }
+        </ul>
+      </nav>
+    </div>
   );
 };
 

--- a/client/src/components/navigation/ButtonIndex.js
+++ b/client/src/components/navigation/ButtonIndex.js
@@ -1,0 +1,32 @@
+import React from "react"
+import { Link } from "react-router-dom"
+
+export const HomeButton = () => {
+  return (
+    <Link to="/">Home</Link>
+  )
+}
+
+export const AboutButton = () => {
+  return (
+    <Link to="/">About</Link>
+  )
+}
+
+export const HowItWorksButton = () => {
+  return (
+    <Link to="/">How It Works</Link>
+  )
+}
+
+export const ContactButton = () => {
+  return (
+    <Link to="/">Contact</Link>
+  )
+}
+
+export const AccountButton = () => {
+  return (
+    <Link to="/">Account</Link>
+  )
+}

--- a/client/src/components/navigation/NavDropDown.js
+++ b/client/src/components/navigation/NavDropDown.js
@@ -1,0 +1,48 @@
+import React, { useState } from "react"
+import { useClickOutside } from "../../services/useClickOutside"
+
+const NavDropDown = ({ className, children }) => {
+  const [open, setOpen] = useState(false)
+
+  const menuRef = useClickOutside(() => setOpen(false))
+
+  const dropDownButtons = children.map((button, index) => {
+    return (
+      <li key={ index } className="hover:text-[#ff485a]">
+        { button }
+      </li>
+    )
+  })
+
+  return (
+    <div ref={menuRef} className={`relative ${className}`}>
+      <DropDownToggle setOpen={setOpen}/>
+      {
+        open && 
+        <DropDownMenu>
+          { dropDownButtons }
+        </DropDownMenu>
+      }
+    </div>
+  )
+}
+
+const DropDownToggle =  ({ setOpen }) => {
+  return (
+    <button onClick={() => setOpen(curr => !curr)}>
+      Menu
+    </button>
+  )
+}
+
+const DropDownMenu = ({ children }) => {
+  return (
+    <div className="absolute z-10 right-0 bg-white bg-opacity-50 rounded-lg shadow-sm w-[200px] p-6">
+      <ul className="flex flex-col space-y-2 items-start">
+        { children }
+      </ul>
+    </div>
+  )
+}
+
+export default NavDropDown

--- a/client/src/services/useClickOutside.js
+++ b/client/src/services/useClickOutside.js
@@ -1,0 +1,19 @@
+import { useRef, useEffect } from "react"
+
+export const useClickOutside = (callback) => {
+  const nodeRef = useRef()
+
+  useEffect(() => {
+    const handler = (event) => {
+      if (!nodeRef.current?.contains(event.target)) {
+        callback()
+      }
+    }
+
+    document.addEventListener("click", handler)
+
+    return () => document.removeEventListener("click", handler)
+  }, [])
+
+  return nodeRef
+}

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,5 +1,3 @@
-const tailwindcss = require("tailwindcss");
-
 module.exports = {
   content: ["./src/components/**/*.js"],
   theme: {
@@ -17,7 +15,6 @@ module.exports = {
     },
   },
   plugins: [
-    require("tailwind-scrollbar-hide"),
-    require("@tailwindcss/aspect-ratio")
+    require("tailwind-scrollbar-hide")
   ],
 }


### PR DESCRIPTION
* Change spacing of navbar buttons
* Add placeholder nav buttons
* Create a button index file that has barebones unstyled button components that get mapped over by the nav bar and allow for different styling depending on whether they are in the nav bar or drop down menu (this is likely to be changed later, but in the interim this implementation allows for a lot of flexibility in styling
* Add drop-down menu
* Add custom hook to handle clicking outside the menu to close it
* clean up tailwind config