### PR TITLE
fix bug with sign out button not properly refreshing page from drop down menu

### DIFF
--- a/client/src/components/layout/NavBar.js
+++ b/client/src/components/layout/NavBar.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { useUser } from "../../services/UserContext";
 import LogoHomeButton from "../navigation/LogoHomeButton";
 import { HomeButton, AboutButton, HowItWorksButton, ContactButton, AccountButton } from "../navigation/ButtonIndex";
@@ -9,6 +9,12 @@ import NavDropDown from "../navigation/NavDropDown";
 
 const NavBar = () => {
   const user = useUser()
+  
+  const [userSignedOut, setUserSignedOut] = useState(false);
+
+  if (userSignedOut) {
+    location.href = "/";
+  }
 
   const navButtons = [
     <HomeButton key="home" />,
@@ -19,7 +25,7 @@ const NavBar = () => {
 
   const userButtons = user ? [
     <AccountButton key="account" />,
-    <SignOutButton key="sign-out" />
+    <SignOutButton key="sign-out" setUserSignedOut={setUserSignedOut} />
   ] : [
     <SignInButton key="sign-in" />,
     <SignUpButton key="sign-up" />

--- a/client/src/components/navigation/NavDropDown.js
+++ b/client/src/components/navigation/NavDropDown.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useState, useEffect } from "react"
 import { useClickOutside } from "../../services/useClickOutside"
 
 const NavDropDown = ({ className, children }) => {
@@ -36,6 +36,10 @@ const DropDownToggle =  ({ setOpen }) => {
 }
 
 const DropDownMenu = ({ children }) => {
+  useEffect(() => {
+    console.log("rendered")
+    return () => console.log("unmounted")
+  }, []) 
   return (
     <div className="absolute z-10 right-0 bg-white bg-opacity-50 rounded-lg shadow-sm w-[200px] p-6">
       <ul className="flex flex-col space-y-2 items-start">

--- a/client/src/components/navigation/SignOutButton.js
+++ b/client/src/components/navigation/SignOutButton.js
@@ -1,12 +1,6 @@
-import React, { useState } from "react";
+import React from "react";
 
-const SignOutButton = () => {
-  const [shouldRedirect, setShouldRedirect] = useState(false);
-
-  if (shouldRedirect) {
-    location.href = "/";
-  }
-
+const SignOutButton = ({ setUserSignedOut }) => {
   const signOut = async (event) => {
     event.preventDefault()
     try {
@@ -21,8 +15,10 @@ const SignOutButton = () => {
         const error = new Error(errorMessage)
         throw(error)
       }
-      const respBody = await response.json()
-      setShouldRedirect(true)
+      const { message } = await response.json()
+      if (message === "User signed out") {
+        setUserSignedOut(true)
+      }
       return { status: "ok" }
     } catch(err) {
       console.error(`Error in fetch: ${err.message}`)


### PR DESCRIPTION
* Move state tracking whether redirection should happen from sign out button to nav bar
* Bug was due to the sign out button instance in the drop down menu unmounting before it had the chance to track its own state change
* Nav Bar now tracks whether the user has logged out and performs the redirect when necessary